### PR TITLE
feat(cache): introduce DiskCache module for raster tile caching

### DIFF
--- a/SlippyGL/SlippyGL.vcxproj
+++ b/SlippyGL/SlippyGL.vcxproj
@@ -136,6 +136,8 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\app\SlippyGL.cpp" />
+    <ClCompile Include="src\cache\CacheTypes.cpp" />
+    <ClCompile Include="src\cache\DiskCache.cpp" />
     <ClCompile Include="src\core\Types.cpp" />
     <ClCompile Include="src\net\CurlHandle.cpp" />
     <ClCompile Include="src\net\HttpClient.cpp" />
@@ -143,6 +145,8 @@
     <ClCompile Include="src\net\TileEndpoint.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="src\cache\CacheTypes.hpp" />
+    <ClInclude Include="src\cache\DiskCache.hpp" />
     <ClInclude Include="src\core\TileMath.hpp" />
     <ClInclude Include="src\core\Types.hpp" />
     <ClInclude Include="src\net\CurlHandle.hpp" />

--- a/SlippyGL/SlippyGL.vcxproj.filters
+++ b/SlippyGL/SlippyGL.vcxproj.filters
@@ -22,6 +22,9 @@
     <Filter Include="Source Files\core">
       <UniqueIdentifier>{1978f929-36de-47fb-b7a2-b95989a153c4}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\cache">
+      <UniqueIdentifier>{8f3a5a4e-adbf-4953-a47b-37acf7f4e2ae}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\core\Types.cpp">
@@ -42,6 +45,12 @@
     <ClCompile Include="src\app\SlippyGL.cpp">
       <Filter>Source Files\app</Filter>
     </ClCompile>
+    <ClCompile Include="src\cache\CacheTypes.cpp">
+      <Filter>Source Files\cache</Filter>
+    </ClCompile>
+    <ClCompile Include="src\cache\DiskCache.cpp">
+      <Filter>Source Files\cache</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\core\TileMath.hpp">
@@ -61,6 +70,12 @@
     </ClInclude>
     <ClInclude Include="src\net\TileEndpoint.hpp">
       <Filter>Source Files\net</Filter>
+    </ClInclude>
+    <ClInclude Include="src\cache\DiskCache.hpp">
+      <Filter>Source Files\cache</Filter>
+    </ClInclude>
+    <ClInclude Include="src\cache\CacheTypes.hpp">
+      <Filter>Source Files\cache</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/SlippyGL/src/cache/CacheTypes.cpp
+++ b/SlippyGL/src/cache/CacheTypes.cpp
@@ -1,0 +1,92 @@
+﻿#include "CacheTypes.hpp"
+#include "nlohmann/json.hpp"
+
+using namespace slippygl::cache;
+using namespace nlohmann;
+
+std::string slippygl::cache::CacheMeta::toJsonString(const CacheMeta& _meta)
+{
+	/*
+		{
+			"etag":"\"abcd1234\"",
+			"lastModified":"Mon, 21 Aug 2025 12:34:56 GMT",
+			"contentType":"image/png",
+			"contentEncoding":null,
+			"contentLength": 10342,
+			"lastAccessUnixSec": 1692600000
+		}
+	*/
+	json j;
+	if (_meta.etag().has_value())
+	{
+		j["etag"] = _meta.etag().value();
+	}
+	if (_meta.lastModified().has_value())
+	{
+		j["lastModified"] = _meta.lastModified().value();
+	}
+	if (_meta.contentType().has_value())
+	{
+		j["contentType"] = _meta.contentType().value();
+	}
+	if (_meta.contentEncoding().has_value())
+	{
+		j["contentEncoding"] = _meta.contentEncoding().value();
+	}
+	j["contentLength"] = _meta.contentLength();
+	j["lastAccessUnixSec"] = _meta.lastAccessUnixSec();
+
+	// 직렬화
+#ifdef PRETTY_PRINT_JSON
+	return j.dump(4);
+#else
+	return j.dump();
+#endif
+}
+
+CacheMeta slippygl::cache::CacheMeta::fromJsonString(const std::string& _json)
+{
+	if (_json.empty())
+	{
+		return CacheMeta();
+	}
+
+	json j = json::parse(_json, nullptr, false);
+	if ((j.is_discarded()) || (!j.is_object()))
+	{
+		return CacheMeta();
+	}
+
+	CacheMeta meta;
+	if ((j.contains("etag")) && (j["etag"].is_string()))
+	{
+		meta.setEtag(j["etag"].get<std::string>());
+	}
+
+	if ((j.contains("lastModified")) && (j["lastModified"].is_string()))
+	{
+		meta.setLastModified(j["lastModified"].get<std::string>());
+	}
+
+	if ((j.contains("contentType")) && (j["contentType"].is_string()))
+	{
+		meta.setContentType(j["contentType"].get<std::string>());
+	}
+
+	if ((j.contains("contentEncoding")) && (j["contentEncoding"].is_string()))
+	{
+		meta.setContentEncoding(j["contentEncoding"].get<std::string>());
+	}
+
+	if ((j.contains("contentLength")) && (j["contentLength"].is_number_unsigned()))
+	{
+		meta.setContentLength(j["contentLength"].get<std::uint64_t>());
+	}
+
+	if ((j.contains("lastAccessUnixSec")) && (j["lastAccessUnixSec"].is_number_unsigned()))
+	{
+		meta.touch(j["lastAccessUnixSec"].get<std::uint64_t>());
+	}
+
+	return meta;
+}

--- a/SlippyGL/src/cache/CacheTypes.hpp
+++ b/SlippyGL/src/cache/CacheTypes.hpp
@@ -1,0 +1,59 @@
+﻿#pragma once
+#include <string>
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace slippygl::cache 
+{
+class CacheConfig 
+{
+public:
+	CacheConfig() = default;
+	explicit CacheConfig(const std::string& rootDir) : rootDir_(rootDir) {}
+
+	const std::string& rootDir() const { return rootDir_; }
+	CacheConfig& setRootDir(const std::string& v) { rootDir_ = v; return *this; }
+
+	// 향후 확장: 최대 용량, 파일 만료일, 폴더명 커스터마이즈 등
+	const std::uint64_t maxBytes() const { return maxBytes_; }
+	CacheConfig& setMaxBytes(const std::uint64_t v) { maxBytes_ = v; return *this; }
+
+	const std::string& rasterDirName() const { return rasterDirName_; }
+	const std::string& metaDirName()   const { return metaDirName_; }
+
+private:
+	std::string rootDir_;
+	std::uint64_t maxBytes_ = 0; // 0 = 무제한
+	std::string rasterDirName_ = "raster";
+	std::string metaDirName_ = "meta";
+};
+
+// HTTP 응답 메타데이터를 캐시에 같이 저장 (사이드카 JSON)
+class CacheMeta 
+{
+public:
+	const std::optional<std::string>& etag() const { return etag_; }
+	const std::optional<std::string>& lastModified() const { return lastModified_; }
+	const std::optional<std::string>& contentType() const { return contentType_; }
+	const std::optional<std::string>& contentEncoding() const { return contentEncoding_; }
+	const std::uint64_t contentLength() const { return contentLength_; }
+	const std::uint64_t lastAccessUnixSec() const { return lastAccessUnixSec_; }
+
+	CacheMeta& setEtag(const std::optional<std::string>& v) { etag_ = v; return *this; }
+	CacheMeta& setLastModified(const std::optional<std::string>& v) { lastModified_ = v; return *this; }
+	CacheMeta& setContentType(const std::optional<std::string>& v) { contentType_ = v; return *this; }
+	CacheMeta& setContentEncoding(const std::optional<std::string>& v) { contentEncoding_ = v; return *this; }
+	CacheMeta& setContentLength(const std::uint64_t v) { contentLength_ = v; return *this; }
+	CacheMeta& touch(const std::uint64_t unixSec) { lastAccessUnixSec_ = unixSec; return *this; }
+
+	static std::string toJsonString(const CacheMeta& _meta);
+	static CacheMeta fromJsonString(const std::string& _json);
+
+private:
+	std::optional<std::string> etag_, lastModified_, contentType_, contentEncoding_;
+	std::uint64_t contentLength_ = 0;
+	std::uint64_t lastAccessUnixSec_ = 0;
+};
+
+} // namespace slippygl::cache

--- a/SlippyGL/src/cache/DiskCache.cpp
+++ b/SlippyGL/src/cache/DiskCache.cpp
@@ -1,0 +1,213 @@
+﻿#include "DiskCache.hpp"
+#include <filesystem>
+#include <fstream>
+
+namespace slippygl::cache
+{
+	DiskCache::DiskCache(const CacheConfig& cfg)
+		: cfg_(cfg)
+	{
+		if (cfg_.rootDir().empty()) {
+			throw std::invalid_argument("Cache root directory must be set");
+		}
+	}
+
+	bool DiskCache::loadRaster(const slippygl::core::TileID& id, std::vector<std::uint8_t>& outBytes) noexcept
+	{
+		std::lock_guard<std::mutex> lock(mtx_);
+		const std::string path = rasterPath(id);
+		
+		if (!std::filesystem::exists(path)) 
+		{
+			return false; // 캐시 미스
+		}
+
+		// 파일 읽기
+		try 
+		{
+			std::ifstream ifs(path, std::ios::binary);
+			if (!ifs) 
+            {
+				return false; // 파일 열기 실패
+			}
+			outBytes.assign(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
+			return true; // 캐시 히트
+		} 
+		catch (const std::exception&) 
+		{
+			return false; // 파일 읽기 실패
+		}
+	}
+
+	bool DiskCache::saveRaster(const slippygl::core::TileID& id,
+							   const std::vector<std::uint8_t>& bytes,
+							   const std::optional<CacheMeta>& meta) noexcept
+	{
+		std::lock_guard<std::mutex> lock(mtx_);
+		const std::string path = rasterPath(id);
+		
+		if (!ensureParentDir(path)) 
+		{
+			return false; // 디렉토리 생성 실패
+		}
+		if (!atomicWriteFile(path + ".part", bytes)) 
+		{
+			return false; // 임시 파일 쓰기 실패
+		}
+		if (meta.has_value()) 
+		{
+			saveMeta(id, meta.value()); // 메타 저장
+		}
+
+		try {
+			std::filesystem::rename(path + ".part", path); // 원자적 rename
+			return true;
+		} catch (const std::exception&) {
+			return false;
+		}
+	}
+
+	bool DiskCache::loadMeta(const slippygl::core::TileID& id, CacheMeta& out) noexcept
+	{
+		std::lock_guard<std::mutex> lock(mtx_);
+		const std::string path = metaPath(id);
+		if (!std::filesystem::exists(path)) 
+		{
+			return false; // 캐시 미스
+		}
+		try 
+		{
+			std::ifstream ifs(path);
+			if (!ifs) 
+			{
+				return false; // 파일 열기 실패
+			}
+			std::string json((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+			out = CacheMeta::fromJsonString(json); // JSON 파싱 (CacheMeta에 fromJson 정적 함수 필요)
+			return true; // 캐시 히트
+		} 
+		catch (const std::exception&) 
+		{
+			return false; // 파일 읽기 실패
+		}
+	}
+
+	bool DiskCache::saveMeta(const slippygl::core::TileID& id, const CacheMeta& meta) noexcept
+	{
+		std::lock_guard<std::mutex> lock(mtx_);
+		const std::string path = metaPath(id);
+		
+		if (!ensureParentDir(path)) 
+		{
+			return false; // 디렉토리 생성 실패
+		}
+		
+		try 
+		{
+			std::string json = CacheMeta::toJsonString(meta); // JSON 직렬화
+			if (!atomicWriteText(path + ".part", json)) {
+				return false;
+			}
+			std::filesystem::rename(path + ".part", path);
+			return true;
+		} 
+		catch (const std::exception&) 
+		{
+			return false; // 파일 쓰기 실패
+		}
+	}
+
+	bool DiskCache::exists(const slippygl::core::TileID& id) const noexcept
+	{
+		std::lock_guard<std::mutex> lock(mtx_);
+		return std::filesystem::exists(rasterPath(id));
+	}
+
+	bool DiskCache::remove(const slippygl::core::TileID& id) noexcept
+	{
+		std::lock_guard<std::mutex> lock(mtx_);
+		try 
+		{
+			std::filesystem::remove(rasterPath(id));
+			std::filesystem::remove(metaPath(id));
+			return true; // 성공적으로 삭제
+		} 
+		catch (const std::exception&) 
+		{
+			return false; // 삭제 실패
+		}
+	}
+
+	void DiskCache::clearAll() noexcept
+	{
+		std::lock_guard<std::mutex> lock(mtx_);
+		try 
+		{
+			std::filesystem::remove_all(cfg_.rootDir());
+		} 
+		catch (const std::exception&) 
+		{
+			// 예외 무시: 전체 캐시 비우기 실패는 무시
+		}
+	}
+
+	std::string DiskCache::rasterPath(const slippygl::core::TileID& id) const
+	{
+		return cfg_.rootDir() + "/" + cfg_.rasterDirName() + "/" + id.toString() + ".png";
+	}
+
+	std::string DiskCache::metaPath(const slippygl::core::TileID& id) const
+	{
+		return cfg_.rootDir() + "/" + cfg_.metaDirName() + "/" + id.toString() + ".json";
+	}
+
+	bool DiskCache::ensureParentDir(const std::string& filePath) const noexcept
+	{
+		try 
+		{
+			std::filesystem::path dir = std::filesystem::path(filePath).parent_path();
+			if (!std::filesystem::exists(dir)) 
+			{
+				std::filesystem::create_directories(dir); // 부모 디렉토리 생성
+			}
+			return true;
+		} 
+		catch (const std::exception&) 
+		{
+			return false; // 디렉토리 생성 실패
+		}
+	}
+
+	bool DiskCache::atomicWriteFile(const std::string& dstPath, const std::vector<std::uint8_t>& bytes) const noexcept
+	{
+		try 
+		{
+			std::ofstream ofs(dstPath, std::ios::binary);
+			if (!ofs)
+			{
+				return false; // 파일 열기 실패
+			}
+			ofs.write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+			return ofs.good(); // 쓰기 성공 여부 반환
+		} 
+		catch (const std::exception&) 
+		{
+			return false; // 예외 발생 시 실패
+		}
+	}
+
+	bool DiskCache::atomicWriteText(const std::string& dstPath, const std::string& text) const noexcept
+	{
+		try 
+		{
+			std::ofstream ofs(dstPath);
+			if (!ofs) return false; // 파일 열기 실패
+			ofs << text;
+			return ofs.good(); // 쓰기 성공 여부 반환
+		} 
+		catch (const std::exception&) 
+		{
+			return false; // 예외 발생 시 실패
+		}
+	}
+};

--- a/SlippyGL/src/cache/DiskCache.hpp
+++ b/SlippyGL/src/cache/DiskCache.hpp
@@ -1,0 +1,47 @@
+﻿#pragma once
+#include <string>
+#include <vector>
+#include <mutex>
+#include <optional>
+#include "../core/Types.hpp"
+#include "CacheTypes.hpp"
+
+namespace slippygl::cache {
+
+// PNG 타일 디스크 캐시 (스레드 안전, 원자적 저장)
+class DiskCache {
+public:
+    explicit DiskCache(const CacheConfig& cfg);
+
+    // PNG 바이트 로드 (히트면 true, miss면 false)
+    bool loadRaster(const slippygl::core::TileID& id, std::vector<std::uint8_t>& outBytes) noexcept;
+
+    // PNG 바이트 저장 (원자적 저장 .part -> rename). 메타도 함께 저장 가능.
+    bool saveRaster(const slippygl::core::TileID& id,
+                    const std::vector<std::uint8_t>& bytes,
+                    const std::optional<CacheMeta>& meta = std::nullopt) noexcept;
+
+    // 메타데이터만 개별 로드/저장
+    bool loadMeta(const slippygl::core::TileID& id, CacheMeta& out) noexcept;
+    bool saveMeta(const slippygl::core::TileID& id, const CacheMeta& meta) noexcept;
+
+    // 존재/삭제/전체 비우기
+    bool exists(const slippygl::core::TileID& id) const noexcept;
+    bool remove(const slippygl::core::TileID& id) noexcept;
+    void clearAll() noexcept;
+
+    // 경로 헬퍼
+    std::string rasterPath(const slippygl::core::TileID& id) const;
+    std::string metaPath(const slippygl::core::TileID& id) const;
+
+private:
+    CacheConfig cfg_;
+    mutable std::mutex mtx_; // 간단 전체 락 (필요 시 타일별 파인그레인 락으로 교체 가능)
+
+    // 내부 유틸
+    bool ensureParentDir(const std::string& filePath) const noexcept;
+    bool atomicWriteFile(const std::string& dstPath, const std::vector<std::uint8_t>& bytes) const noexcept;
+    bool atomicWriteText(const std::string& dstPath, const std::string& text) const noexcept;
+};
+
+} // namespace slippygl::cache


### PR DESCRIPTION
### Summary
Adds the DiskCache module to provide persistent on-disk caching for raster PNG tiles.

### Details
- `CacheConfig`: holds root dir, maxBytes, directory names
- `CacheMeta`: stores HTTP metadata (ETag, Last-Modified, ContentType, etc.)
- `DiskCache`:
  - `loadRaster/saveRaster` with atomic writes (.part → rename)
  - `loadMeta/saveMeta` with JSON sidecar (nlohmann-json)
  - `exists/remove/clearAll` for file lifecycle
- Thread safety ensured with a global mutex (future: finer-grained locking)

### Test
- Added smoke tests:
  - MISS → SAVE → HIT roundtrip
  - Metadata roundtrip
  - Overwrite existing file
  - exists/remove/clearAll behavior
  - Basic concurrency stress (multi-thread save/load)

### Next Steps
- Integrate DiskCache into TileDownloader
- Use CacheMeta for conditional HTTP requests (If-None-Match / If-Modified-Since)
- Add LRU / max size pruning
