### PR TITLE
feat(tile): implement TileDownloader with cache + network orchestration

### DIFF
--- a/SlippyGL/SlippyGL.vcxproj
+++ b/SlippyGL/SlippyGL.vcxproj
@@ -143,6 +143,7 @@
     <ClCompile Include="src\net\HttpClient.cpp" />
     <ClCompile Include="src\net\HttpTypes.cpp" />
     <ClCompile Include="src\net\TileEndpoint.cpp" />
+    <ClCompile Include="src\tile\TileDownloader.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\cache\CacheTypes.hpp" />
@@ -153,6 +154,7 @@
     <ClInclude Include="src\net\HttpClient.hpp" />
     <ClInclude Include="src\net\HttpTypes.hpp" />
     <ClInclude Include="src\net\TileEndpoint.hpp" />
+    <ClInclude Include="src\tile\TileDownloader.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/SlippyGL/SlippyGL.vcxproj.filters
+++ b/SlippyGL/SlippyGL.vcxproj.filters
@@ -25,6 +25,9 @@
     <Filter Include="Source Files\cache">
       <UniqueIdentifier>{8f3a5a4e-adbf-4953-a47b-37acf7f4e2ae}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\tile">
+      <UniqueIdentifier>{bb96faed-2b7d-4d74-b52c-129c46463e5a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\core\Types.cpp">
@@ -51,6 +54,9 @@
     <ClCompile Include="src\cache\DiskCache.cpp">
       <Filter>Source Files\cache</Filter>
     </ClCompile>
+    <ClCompile Include="src\tile\TileDownloader.cpp">
+      <Filter>Source Files\tile</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\core\TileMath.hpp">
@@ -76,6 +82,9 @@
     </ClInclude>
     <ClInclude Include="src\cache\CacheTypes.hpp">
       <Filter>Source Files\cache</Filter>
+    </ClInclude>
+    <ClInclude Include="src\tile\TileDownloader.hpp">
+      <Filter>Source Files\tile</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/SlippyGL/src/cache/DiskCache.cpp
+++ b/SlippyGL/src/cache/DiskCache.cpp
@@ -56,7 +56,7 @@ namespace slippygl::cache
 		}
 		if (meta.has_value()) 
 		{
-			saveMeta(id, meta.value()); // 메타 저장
+			saveMetaInternal(id, meta.value()); // 내부 메서드 호출 (락 없음)
 		}
 
 		try {
@@ -95,6 +95,12 @@ namespace slippygl::cache
 	bool DiskCache::saveMeta(const slippygl::core::TileID& id, const CacheMeta& meta) noexcept
 	{
 		std::lock_guard<std::mutex> lock(mtx_);
+		return saveMetaInternal(id, meta);
+	}
+
+	bool DiskCache::saveMetaInternal(const slippygl::core::TileID& id, const CacheMeta& meta) noexcept
+	{
+		// 이 메서드는 이미 락이 획득된 상태에서 호출됨 (락 없음)
 		const std::string path = metaPath(id);
 		
 		if (!ensureParentDir(path)) 

--- a/SlippyGL/src/cache/DiskCache.hpp
+++ b/SlippyGL/src/cache/DiskCache.hpp
@@ -42,6 +42,9 @@ private:
     bool ensureParentDir(const std::string& filePath) const noexcept;
     bool atomicWriteFile(const std::string& dstPath, const std::vector<std::uint8_t>& bytes) const noexcept;
     bool atomicWriteText(const std::string& dstPath, const std::string& text) const noexcept;
+    
+    // 락 없이 호출되는 내부 메서드 (이미 락이 획득된 상태에서 호출)
+    bool saveMetaInternal(const slippygl::core::TileID& id, const CacheMeta& meta) noexcept;
 };
 
 } // namespace slippygl::cache

--- a/SlippyGL/src/core/TileMath.hpp
+++ b/SlippyGL/src/core/TileMath.hpp
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include <cmath>
 #include <algorithm>
 #include "Types.hpp"

--- a/SlippyGL/src/tile/TileDownloader.cpp
+++ b/SlippyGL/src/tile/TileDownloader.cpp
@@ -1,0 +1,186 @@
+﻿#include "TileDownloader.hpp"
+#include <spdlog/spdlog.h>
+
+namespace slippygl::tile {
+
+TileDownloader::TileDownloader(slippygl::cache::DiskCache& disk,
+                               slippygl::net::HttpClient& http,
+                               slippygl::net::TileEndpoint& endpoint)
+: disk_(disk), http_(http), ep_(endpoint) 
+{}
+
+bool TileDownloader::tryLoadFromDisk(const slippygl::core::TileID& id,
+                                     std::vector<std::uint8_t>& outBytes,
+                                     std::optional<slippygl::cache::CacheMeta>& outMeta) const
+{
+    std::lock_guard<std::mutex> lk(mtx_);
+    bool hit = disk_.loadRaster(id, outBytes);
+	if (!hit)
+	{
+		return false;
+	}
+
+    slippygl::cache::CacheMeta m;
+    if (disk_.loadMeta(id, m))
+    {
+        outMeta = m;
+    }
+    else
+    {
+        outMeta.reset();
+    }
+    return true;
+}
+
+FetchResult TileDownloader::ensureRaster(const slippygl::core::TileID& id) 
+{
+    FetchResult r;
+
+    // 1) 디스크 캐시 조회
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        if (disk_.loadRaster(id, r.body)) 
+        {
+            slippygl::cache::CacheMeta m;
+            if (disk_.loadMeta(id, m))
+            {
+                r.meta = m;
+            }
+            r.code = FetchCode::kHitDisk;
+            r.httpStatus = 0;
+            return r;
+        }
+    }
+
+    // 2) 네트워크 다운로드
+    const std::string url = ep_.rasterUrl(id);
+    auto resp = http_.get(url);
+
+    r.httpStatus  = resp.status();
+    r.effectiveUrl = resp.effectiveUrl();
+
+    if (resp.status() == 200) 
+    {
+        r.body = resp.body();
+        // 메타 구성
+        slippygl::cache::CacheMeta meta;
+        if (const auto& e = resp.headers().etag())
+        {
+            meta.setEtag(e);
+        }
+        if (const auto& lm = resp.headers().lastModified())
+        {
+            meta.setLastModified(lm);
+        }
+        if (const auto& ct = resp.headers().contentType())
+        {
+            meta.setContentType(ct);
+        }
+        if (const auto& ce = resp.headers().contentEncoding())
+        {
+            meta.setContentEncoding(ce);
+        }
+        if (const auto& cl = resp.headers().contentLength())
+        {
+            meta.setContentLength(*cl);
+        }
+        meta.touch(static_cast<std::uint64_t>(time(nullptr)));
+
+        // 3) 저장 (원자적)
+        {
+            std::lock_guard<std::mutex> lk(mtx_);
+            disk_.saveRaster(id, r.body, meta);
+        }
+        r.meta = meta;
+        r.code = FetchCode::kDownloaded;
+        return r;
+    }
+    else if (resp.status() == 404) 
+    {
+        spdlog::warn("Tile not found: {}", url);
+        r.code = FetchCode::kNotFound;
+        return r;
+    }
+    else 
+    {
+        spdlog::warn("HTTP error {} for {}", resp.status(), url);
+        r.code = FetchCode::kError;
+        return r;
+    }
+}
+
+FetchResult TileDownloader::ensureRasterConditional(const slippygl::core::TileID& id) 
+{
+    // 캐시 메타 있으면 If-None-Match/If-Modified-Since 헤더로 조건부 요청
+    std::optional<slippygl::cache::CacheMeta> cachedMeta;
+    std::vector<std::uint8_t> cachedBytes;
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        if (disk_.loadRaster(id, cachedBytes))
+        {
+            slippygl::cache::CacheMeta m;
+            if (disk_.loadMeta(id, m))
+            {
+                cachedMeta = m;
+            }
+        }
+    }
+    if (!cachedMeta.has_value()) 
+    {
+        return ensureRaster(id); // 메타 없으면 일반 경로
+    }
+
+    slippygl::net::Conditional cond;
+    if (cachedMeta->etag())
+    {
+        cond.setIfNoneMatch(*cachedMeta->etag());
+    }
+    if (cachedMeta->lastModified())
+    {
+        cond.setIfModifiedSince(*cachedMeta->lastModified());
+    }
+
+    const std::string url = ep_.rasterUrl(id);
+    auto resp = http_.get(url, /*headers*/nullptr, &cond);
+
+    FetchResult r;
+    r.httpStatus = resp.status();
+    r.effectiveUrl = resp.effectiveUrl();
+
+    if (resp.status() == 304) 
+    { 
+        // Not Modified → 캐시 재사용
+        r.code = FetchCode::kNotModified;
+        r.body = std::move(cachedBytes);
+        r.meta = cachedMeta;
+        // 접근 시간만 갱신해 저장하고 싶다면 DiskCache.saveMeta(...) 호출
+        return r;
+    }
+    if (resp.status() == 200) 
+    {
+        r.body = resp.body();
+        slippygl::cache::CacheMeta meta;
+        if (auto e = resp.headers().etag())           meta.setEtag(e);
+        if (auto lm = resp.headers().lastModified())  meta.setLastModified(lm);
+        if (auto ct = resp.headers().contentType())   meta.setContentType(ct);
+        if (auto ce = resp.headers().contentEncoding()) meta.setContentEncoding(ce);
+        if (auto cl = resp.headers().contentLength())   meta.setContentLength(*cl);
+        meta.touch(static_cast<std::uint64_t>(time(nullptr)));
+        {
+            std::lock_guard<std::mutex> lk(mtx_);
+            (void)disk_.saveRaster(id, r.body, meta);
+        }
+        r.meta = meta;
+        r.code = FetchCode::kDownloaded;
+        return r;
+    }
+    if (resp.status() == 404) 
+    {
+        r.code = FetchCode::kNotFound;
+        return r;
+    }
+    r.code = FetchCode::kError;
+    return r;
+}
+
+} // namespace slippygl::tile

--- a/SlippyGL/src/tile/TileDownloader.hpp
+++ b/SlippyGL/src/tile/TileDownloader.hpp
@@ -1,0 +1,67 @@
+﻿#pragma once
+#include <vector>
+#include <optional>
+#include <string>
+#include <cstdint>
+#include <mutex>
+
+#include "../core/Types.hpp"        // TileID
+#include "../net/HttpClient.hpp"    // HttpClient, NetConfig, HttpResponse
+#include "../net/TileEndpoint.hpp"  // TileEndpoint
+#include "../cache/DiskCache.hpp"   // DiskCache, CacheMeta
+
+namespace slippygl::tile
+{
+enum class FetchCode : uint8_t
+{
+	kHitDisk = 0,     // 디스크 캐시에서 바로 가져옴
+	kDownloaded,      // 네트워크에서 받아와서 캐시에 저장
+	kNotModified,     // 304 (조건부 요청 성공, 캐시 재사용)
+	kNotFound,        // 404 등
+	kError            // 네트워크/IO 오류
+};
+
+struct FetchResult
+{
+	FetchCode code = FetchCode::kError;
+	long      httpStatus = 0;                 // 200/304/404/...
+	std::string effectiveUrl;                 // redirect 후 최종 URL
+	std::optional<slippygl::cache::CacheMeta> meta; // 응답/캐시 메타
+	// 바디는 PNG 바이트
+	std::vector<std::uint8_t> body;
+
+	bool ok() const
+	{
+		return ((code == FetchCode::kHitDisk) || (code == FetchCode::kDownloaded) || (code == FetchCode::kNotModified));
+	}
+};
+
+// 단일 쓰레드 동기 구현(초기). 이후 multi-queue/취소 토큰은 확장.
+class TileDownloader
+{
+public:
+	TileDownloader(slippygl::cache::DiskCache& disk,
+		slippygl::net::HttpClient& http,
+		slippygl::net::TileEndpoint& endpoint);
+
+	// 기본 경로: 캐시 히트면 바로 반환, 미스면 다운로드 후 저장
+	FetchResult ensureRaster(const slippygl::core::TileID& id);
+
+	// 조건부 요청 사용(캐시에 메타가 있으면 If-None-Match / If-Modified-Since 세팅)
+	// 캐시에 메타가 없으면 ensureRaster와 동일 동작
+	FetchResult ensureRasterConditional(const slippygl::core::TileID& id);
+
+	// 캐시만 확인(네트워크 접근 X)
+	bool tryLoadFromDisk(const slippygl::core::TileID& id, std::vector<std::uint8_t>& outBytes,
+		std::optional<slippygl::cache::CacheMeta>& outMeta) const;
+
+private:
+	slippygl::cache::DiskCache& disk_;
+	slippygl::net::HttpClient& http_;
+	slippygl::net::TileEndpoint& ep_;
+
+	// 동시성 보호 (초기엔 coarse lock; 나중에 타일별 세분화 가능)
+	mutable std::mutex mtx_;
+};
+
+} // namespace slippygl::tile


### PR DESCRIPTION
### Summary
Adds the TileDownloader module, which orchestrates raster tile fetching through DiskCache, HttpClient, and TileEndpoint.

### Details
- New types:
  - `FetchCode` enum: HitDisk / Downloaded / NotModified / NotFound / Error
  - `FetchResult`: wraps status code, effective URL, optional CacheMeta, and PNG body
- `TileDownloader` class:
  - `ensureRaster()`: check DiskCache, fallback to HttpClient, save to cache
  - `ensureRasterConditional()`: use cached ETag/Last-Modified to send conditional requests; 304 results reuse cache
  - `tryLoadFromDisk()`: fast path for cache-only read
- Thread-safety: coarse `std::mutex` around disk/network operations (future: finer per-tile locks)

### Test
- Verified smoke test:
  - First call downloads tile, writes cache, returns bytes
  - Second call hits disk (cache hit)
  - Conditional call returns 304 Not Modified and reuses cache
- Confirmed files appear under `cache/raster/z/x/y.png` and `cache/meta/z/x/y.json`

### Next Steps
- Add per-tile locking to avoid duplicate concurrent downloads
- Add LRU pruning based on CacheConfig.maxBytes
- Extend API for vector tiles (MVT) and DEM support
- Integrate into render pipeline (decode + texture upload)
