### PR TITLE
fix(build): CMake+MSVC 빌드/링크 정상화 (/utf-8, stb_image 중복 제거)

### DIFF
--- a/SlippyGL/CMakeLists.txt
+++ b/SlippyGL/CMakeLists.txt
@@ -72,7 +72,9 @@ endif()
 
 # ---- Warnings / nice defaults ----
 if (MSVC)
-  target_compile_options(SlippyGL PRIVATE /W4 /permissive-)
+  # /utf-8: source/exec charset UTF-8 (Korean comments are UTF-8 w/o BOM;
+  # without this MSVC reads them as the system code page and mis-tokenizes).
+  target_compile_options(SlippyGL PRIVATE /W4 /permissive- /utf-8)
 else()
   target_compile_options(SlippyGL PRIVATE -Wall -Wextra -Wpedantic)
 endif()

--- a/SlippyGL/src/decode/PngCodec.cpp
+++ b/SlippyGL/src/decode/PngCodec.cpp
@@ -1,11 +1,7 @@
 ﻿#include "PngCodec.hpp"
 
-// STB Image library configuration (must be before include)
-#define STB_IMAGE_IMPLEMENTATION
-#define STBI_NO_STDIO          // Disable file I/O (memory only)
-#define STBI_ONLY_PNG          // PNG only
-
-// vcpkg stb package uses this path
+// stb_image declarations only. The single implementation translation unit is
+// external/stb_image_impl.cpp (defines STB_IMAGE_IMPLEMENTATION there).
 #include <stb_image.h>
 
 namespace slippygl::decode

--- a/SlippyGL/src/external/stb_image_impl.cpp
+++ b/SlippyGL/src/external/stb_image_impl.cpp
@@ -1,3 +1,7 @@
-﻿// SlippyGL/src/stb_image_impl.cpp
+// Single translation unit that compiles the stb_image implementation.
+// Keep these defines here (not in PngCodec.cpp) so there is exactly one
+// implementation in the program.
 #define STB_IMAGE_IMPLEMENTATION
+#define STBI_NO_STDIO   // memory-only (no file I/O)
+#define STBI_ONLY_PNG   // PNG only
 #include <stb_image.h>


### PR DESCRIPTION
## 개요
PR #21(병합됨)의 코드를 **CMake + MSVC(VS2022)로 실제 빌드·실행 검증**하던 중 발견한
두 가지 빌드 차단 문제를 수정합니다. (둘 다 기존 잠재 이슈)

## 수정
1. **`/utf-8` 추가 (MSVC)** — UTF-8(BOM 없음) 한글 주석을 시스템 코드페이지(CP949)로
   잘못 읽어 토큰화가 깨지던 문제. `'gl' undeclared` 연쇄, 인자 개수 오인식(C2065/C2660) 유발.
2. **stb_image 중복 구현 제거** — `PngCodec.cpp`와 `stb_image_impl.cpp`가 모두
   `STB_IMAGE_IMPLEMENTATION`을 정의해 `LNK2005`(stbi_* 중복) 발생.
   구현을 `stb_image_impl.cpp` 하나로 통합(`STBI_NO_STDIO`/`STBI_ONLY_PNG`도 이전),
   `PngCodec.cpp`는 선언만 include.
   - 참고: 기존 `.vcxproj`는 `stb_image_impl.cpp`를 빌드에 포함하지 않아 VS 빌드는
     우연히 통과했지만, CMake(GLOB)는 둘 다 컴파일해 충돌.

## 검증 (Release, MSVC 14.44)
- ✅ 빌드 성공, 링크 성공 (`SlippyGL.exe`)
- ✅ 실행: OpenGL 3.3 컨텍스트 생성, `segoeui.ttf` 로드(저작자 표시 ©),
  OSM 타일 다운로드→디코드→인메모리 캐시, ~140fps 안정 동작, 에러 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)