### PR TITLE
fix(zoom): 줌 인/아웃 시 타일이 사라지는 버그 수정

### DIFF
--- a/SlippyGL/src/app/SlippyGL.cpp
+++ b/SlippyGL/src/app/SlippyGL.cpp
@@ -99,7 +99,8 @@ void RunTileRenderDemo()
     spdlog::info("Visible tiles will be loaded dynamically");
 
     int frameCount = 0;
-    int lastZoomLevel = initialZoom;
+    int tileZoom = initialZoom;       // 현재 타일 줌 레벨(프레임 간 유지되는 상태)
+    int lastZoomLevel = initialZoom;  // 로그 출력용 직전 값
 
     while (!gl.shouldClose()) {
         gl.poll();
@@ -113,35 +114,34 @@ void RunTileRenderDemo()
         const int fbW = gl.width();
         const int fbH = gl.height();
 
-        // 카메라 스케일 -> 줌 레벨 계산
-        // scale 1.0 = 기본 줌 레벨, 0.5 = 줌 아웃, 2.0 = 줌 인
-        const float scale = camera.scale();
-        int zoomLevel = initialZoom;
-
-        // 스케일에 따른 줌 레벨 조정 (대략적 로그 스케일)
-        if (scale < 0.5f) {
-            zoomLevel = std::max(0, initialZoom - 2);
-        } else if (scale < 0.75f) {
-            zoomLevel = std::max(0, initialZoom - 1);
-        } else if (scale > 2.0f) {
-            zoomLevel = std::min(19, initialZoom + 2);
-        } else if (scale > 1.5f) {
-            zoomLevel = std::min(19, initialZoom + 1);
+        // 카메라 스케일이 임계치를 넘으면 타일 줌 레벨을 한 단계 바꾸고
+        // 카메라 좌표계를 재매핑한다(화면 뷰는 그대로 보존). 월드 픽셀 좌표계가
+        // 항상 현재 타일 줌과 일치하도록 유지해야 타일이 정상 표시된다.
+        // (scale이 두 배가 되면 한 레벨 인, 절반이 되면 한 레벨 아웃)
+        constexpr int kMinZoom = 0;
+        constexpr int kMaxZoom = 19;
+        while (camera.scale() > 2.0f && tileZoom < kMaxZoom) {
+            ++tileZoom;
+            camera.applyZoomStep(2.0f);   // worldOrigin*2, scale/2
+        }
+        while (camera.scale() < 0.5f && tileZoom > kMinZoom) {
+            --tileZoom;
+            camera.applyZoomStep(0.5f);   // worldOrigin/2, scale*2
         }
 
         // 줌 레벨이 바뀌면 로그 출력
-        if (zoomLevel != lastZoomLevel) {
-            spdlog::info("Zoom level changed: {} -> {} (scale: {:.2f})",
-                lastZoomLevel, zoomLevel, scale);
-            lastZoomLevel = zoomLevel;
+        if (tileZoom != lastZoomLevel) {
+            spdlog::info("Tile zoom level: {} -> {} (scale: {:.2f})",
+                lastZoomLevel, tileZoom, camera.scale());
+            lastZoomLevel = tileZoom;
         }
 
         // TileRenderer로 화면에 보이는 모든 타일 렌더링
-        const int tilesRendered = tileRenderer.drawTiles(quadRenderer, camera, zoomLevel, fbW, fbH);
+        const int tilesRendered = tileRenderer.drawTiles(quadRenderer, camera, tileZoom, fbW, fbH);
 
         // 디버그 오버레이(F3 토글): 타일 경계 + z/x/y
         if (inputHandler.debugMode()) {
-            tileRenderer.drawDebugOverlay(overlay, camera, zoomLevel, fbW, fbH);
+            tileRenderer.drawDebugOverlay(overlay, camera, tileZoom, fbW, fbH);
         }
 
         // 저작자 표시(우하단 상시 노출) — 항상 최상단에 그린다

--- a/SlippyGL/src/render/Camera2D.cpp
+++ b/SlippyGL/src/render/Camera2D.cpp
@@ -44,6 +44,18 @@ void Camera2D::reset() noexcept
     scale_ = 1.0f;
 }
 
+void Camera2D::applyZoomStep(float factor) noexcept
+{
+    // worldOrigin *= factor, scale /= factor preserves the on-screen mapping:
+    //   screen = (world - origin) * scale
+    // After world' = world*factor, origin' = origin*factor, scale' = scale/factor:
+    //   screen' = (world*factor - origin*factor) * (scale/factor)
+    //           = (world - origin) * scale = screen   (unchanged)
+    worldOriginX_ *= factor;
+    worldOriginY_ *= factor;
+    scale_ /= factor;
+}
+
 glm::vec2 Camera2D::screenToWorld(float sx, float sy) const noexcept
 {
     // Screen coordinate to world coordinate

--- a/SlippyGL/src/render/Camera2D.hpp
+++ b/SlippyGL/src/render/Camera2D.hpp
@@ -44,6 +44,19 @@ namespace slippygl::render
         void reset() noexcept;
 
         /**
+         * Remap the world frame when the discrete tile zoom level changes.
+         *
+         * "World pixels" are tile-index * tileSize, so the space doubles per
+         * zoom level. When the active tile zoom changes by delta levels, call
+         * this with factor = 2^delta (zoom in) or 2^-delta (zoom out). It scales
+         * worldOrigin by factor and scale by 1/factor, which keeps every point's
+         * on-screen position identical across the level switch (so the view does
+         * not jump) while making tile world positions consistent with the new
+         * zoom level.
+         */
+        void applyZoomStep(float factor) noexcept;
+
+        /**
          * Get current scale
          */
         float scale() const noexcept { return scale_; }

--- a/SlippyGL/src/tile/TileGrid.hpp
+++ b/SlippyGL/src/tile/TileGrid.hpp
@@ -68,17 +68,18 @@ namespace slippygl::tile
             );
 
             // World pixels to tile indices
-            range.minX = TileCoord::worldPxToTileIndex(topLeft.x, tileSizePx);
-            range.maxX = TileCoord::worldPxToTileIndex(bottomRight.x, tileSizePx);
-            range.minY = TileCoord::worldPxToTileIndex(topLeft.y, tileSizePx);
-            range.maxY = TileCoord::worldPxToTileIndex(bottomRight.y, tileSizePx);
+            const int rawMinX = TileCoord::worldPxToTileIndex(topLeft.x, tileSizePx);
+            const int rawMaxX = TileCoord::worldPxToTileIndex(bottomRight.x, tileSizePx);
+            const int rawMinY = TileCoord::worldPxToTileIndex(topLeft.y, tileSizePx);
+            const int rawMaxY = TileCoord::worldPxToTileIndex(bottomRight.y, tileSizePx);
 
-            // Clamp to valid tile range (no wrapping for now)
-            const int maxIdx = (1 << zoom) - 1;
-            range.minX = std::max(0, range.minX);
-            range.maxX = std::min(maxIdx, range.maxX);
-            range.minY = std::max(0, range.minY);
-            range.maxY = std::min(maxIdx, range.maxY);
+            // Clamp every index to [0, 2^zoom - 1]. Clamping BOTH ends (not just
+            // min-with-0 and max-with-maxIdx) prevents an inverted minX>maxX
+            // range, which would silently render zero tiles. (no wrapping yet)
+            range.minX = TileCoord::clampTileIndex(rawMinX, zoom);
+            range.maxX = TileCoord::clampTileIndex(rawMaxX, zoom);
+            range.minY = TileCoord::clampTileIndex(rawMinY, zoom);
+            range.maxY = TileCoord::clampTileIndex(rawMaxY, zoom);
 
             return range;
         }


### PR DESCRIPTION
## 문제
줌 인/아웃을 하면 타일이 표시되지 않음.

## 원인
\"월드 픽셀\" 좌표(`타일인덱스 × 256`)는 타일 줌 레벨마다 스케일이 달라지는데,
카메라의 `worldOrigin`/`scale`은 초기 줌(12)에 고정된 채 앱이 타일 줌 레벨을
바꿀 때 **좌표계를 재매핑하지 않음.**
- 줌아웃: 요청 타일 인덱스가 새 레벨의 최대 인덱스를 초과 → `TileGrid`가
  `maxX`만 클램프하고 `minX`는 안 잘라 **minX > maxX(역전 범위) → 타일 0개**
- 줌인: 어긋난 좌표계에 타일이 배치돼 화면 밖/엉뚱한 위치

## 수정
- **`Camera2D::applyZoomStep(factor)`**: `worldOrigin *= factor; scale /= factor;`
  → 레벨 전환 전후로 모든 점의 화면 위치가 동일하게 보존됨(뷰 점프 없음)
- **앱 루프**: 정적 `scale→레벨` 매핑을 상태 기반 스텝으로 교체
  (`scale>2`→레벨+1 & `applyZoomStep(2)`, `scale<0.5`→레벨-1 & `applyZoomStep(0.5)`)
  → 월드 좌표계가 항상 현재 타일 줌과 일치, `scale`은 ~[0.5,2] 유지
- **`TileGrid::computeVisibleRange`**: min/max 인덱스를 둘 다 `[0,2^z-1]`로 클램프
  → 역전 범위로 조용히 0개 렌더되는 일 방지

## 검증
- 독립 테스트(Camera2D+TileGrid): z=6/12/13/19 전부 **비지 않고, 범위 내, 지리 보존**
  타일 반환 (서울이 각 줌의 올바른 인덱스로 매핑됨). 기존 코드면 줌아웃 시 0개.
- 전체 앱 빌드 성공(MSVC Release) + 실행 시 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)