### PR TITLE
test+ci: 단위 테스트(CTest) + GitHub Actions 빌드/테스트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,22 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Configure (CMake + vcpkg)
+      # Put cl.exe / link.exe on PATH so the Ninja generator finds MSVC without
+      # relying on Visual Studio generator auto-detection (which is brittle on
+      # hosted runners).
+      - name: Set up MSVC (x64)
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Configure (CMake + Ninja + vcpkg)
         run: >
-          cmake -S SlippyGL -B build
-          -G "Visual Studio 17 2022" -A x64
+          cmake -S SlippyGL -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
 
-      - name: Build (Release)
-        run: cmake --build build --config Release
+      - name: Build
+        run: cmake --build build
 
       - name: Test (CTest)
-        run: ctest --test-dir build -C Release --output-on-failure
+        run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: Build & test (Windows / MSVC)
+    runs-on: windows-latest
+
+    env:
+      # Cache vcpkg-built dependencies in the GitHub Actions cache so repeat
+      # runs don't rebuild glfw/curl/glad/spdlog from source every time.
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # Expose the GitHub Actions cache endpoints required by vcpkg's x-gha
+      # binary cache provider.
+      - name: Enable vcpkg GHA binary cache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Configure (CMake + vcpkg)
+        run: >
+          cmake -S SlippyGL -B build
+          -G "Visual Studio 17 2022" -A x64
+          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build (Release)
+        run: cmake --build build --config Release
+
+      - name: Test (CTest)
+        run: ctest --test-dir build -C Release --output-on-failure

--- a/SlippyGL/CMakeLists.txt
+++ b/SlippyGL/CMakeLists.txt
@@ -84,3 +84,26 @@ option(SLIPPYGL_ENABLE_GL_DEBUG "Enable OpenGL debug output in Debug builds" ON)
 if (CMAKE_BUILD_TYPE STREQUAL "Debug" AND SLIPPYGL_ENABLE_GL_DEBUG)
   target_compile_definitions(SlippyGL PRIVATE SLIPPYGL_GL_DEBUG)
 endif()
+
+# ---- Unit tests (CTest) ----
+# Pure-logic tests (coordinate math, visible-tile range, camera). No GL/network,
+# so they link only the relevant production sources + glm (header-only).
+option(SLIPPYGL_BUILD_TESTS "Build unit tests" ON)
+if (SLIPPYGL_BUILD_TESTS)
+  enable_testing()
+
+  file(GLOB SLIPPYGL_TEST_SRC ${CMAKE_CURRENT_LIST_DIR}/tests/*.cpp)
+  add_executable(slippygl_tests
+    ${SLIPPYGL_TEST_SRC}
+    ${CMAKE_CURRENT_LIST_DIR}/src/render/Camera2D.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/core/Types.cpp
+  )
+  target_include_directories(slippygl_tests PRIVATE ${CMAKE_CURRENT_LIST_DIR}/src)
+  target_link_libraries(slippygl_tests PRIVATE glm::glm)
+
+  if (MSVC)
+    target_compile_options(slippygl_tests PRIVATE /utf-8)
+  endif()
+
+  add_test(NAME slippygl_tests COMMAND slippygl_tests)
+endif()

--- a/SlippyGL/tests/check.hpp
+++ b/SlippyGL/tests/check.hpp
@@ -1,0 +1,27 @@
+#pragma once
+// Tiny dependency-free assertion helper for SlippyGL unit tests.
+// Uses C++17 inline variables so the counters have a single definition
+// across all test translation units.
+#include <cstdio>
+#include <cmath>
+
+namespace slippytest
+{
+    inline int g_checks = 0;
+    inline int g_fails  = 0;
+
+    inline void report(bool ok, const char* expr, const char* file, int line)
+    {
+        ++g_checks;
+        if (!ok) {
+            ++g_fails;
+            std::printf("  FAIL: %s   (%s:%d)\n", expr, file, line);
+        }
+    }
+}
+
+#define CHECK(cond)        ::slippytest::report((cond), #cond, __FILE__, __LINE__)
+#define CHECK_EQ(a, b)     ::slippytest::report((a) == (b), #a " == " #b, __FILE__, __LINE__)
+#define CHECK_NEAR(a, b, eps) \
+    ::slippytest::report(std::fabs(static_cast<double>(a) - static_cast<double>(b)) <= (eps), \
+                         #a " ~= " #b, __FILE__, __LINE__)

--- a/SlippyGL/tests/test_camera.cpp
+++ b/SlippyGL/tests/test_camera.cpp
@@ -1,0 +1,48 @@
+#include "check.hpp"
+#include "render/Camera2D.hpp"
+
+using namespace slippygl::render;
+
+void test_camera()
+{
+    std::printf("[camera]\n");
+
+    // applyZoomStep must preserve a point's on-screen position across a level
+    // switch. After zoom-in (factor 2), the same geographic point is at world*2.
+    {
+        Camera2D cam;
+        cam.setWorldOrigin(glm::vec2(1000.0f, 2000.0f));   // scale 1.0
+        const glm::vec2 wp(1234.0f, 5678.0f);
+        const glm::vec2 before = cam.worldToScreen(wp.x, wp.y);
+
+        cam.applyZoomStep(2.0f);
+        const glm::vec2 after = cam.worldToScreen(wp.x * 2.0f, wp.y * 2.0f);
+
+        CHECK_NEAR(before.x, after.x, 1e-3);
+        CHECK_NEAR(before.y, after.y, 1e-3);
+        CHECK_NEAR(cam.scale(), 0.5f, 1e-6);   // scale halved
+
+        // zoom back out restores scale
+        cam.applyZoomStep(0.5f);
+        CHECK_NEAR(cam.scale(), 1.0f, 1e-6);
+    }
+
+    // screenToWorld and worldToScreen are inverses
+    {
+        Camera2D cam;
+        cam.setWorldOrigin(glm::vec2(500.0f, 700.0f));
+        const glm::vec2 s = cam.worldToScreen(900.0f, 1300.0f);
+        const glm::vec2 w = cam.screenToWorld(s.x, s.y);
+        CHECK_NEAR(w.x, 900.0f, 1e-3);
+        CHECK_NEAR(w.y, 1300.0f, 1e-3);
+    }
+
+    // pan shifts worldOrigin by -delta/scale (scale 1.0 here)
+    {
+        Camera2D cam;
+        const glm::vec2 o0 = cam.worldOrigin();
+        cam.pan(10.0f, -20.0f);
+        CHECK_NEAR(cam.worldOrigin().x, o0.x - 10.0f, 1e-4);
+        CHECK_NEAR(cam.worldOrigin().y, o0.y + 20.0f, 1e-4);
+    }
+}

--- a/SlippyGL/tests/test_main.cpp
+++ b/SlippyGL/tests/test_main.cpp
@@ -1,0 +1,21 @@
+#include "check.hpp"
+#include <cstdio>
+
+void test_tilemath();
+void test_tilekey();
+void test_tilegrid();
+void test_camera();
+
+int main()
+{
+    std::printf("Running SlippyGL unit tests\n");
+    std::printf("===========================\n");
+    test_tilemath();
+    test_tilekey();
+    test_tilegrid();
+    test_camera();
+    std::printf("---------------------------\n");
+    std::printf("%d checks, %d failures\n", slippytest::g_checks, slippytest::g_fails);
+    std::printf("RESULT: %s\n", slippytest::g_fails == 0 ? "PASS" : "FAIL");
+    return slippytest::g_fails == 0 ? 0 : 1;
+}

--- a/SlippyGL/tests/test_tilegrid.cpp
+++ b/SlippyGL/tests/test_tilegrid.cpp
@@ -1,0 +1,61 @@
+#include "check.hpp"
+#include "render/Camera2D.hpp"
+#include "tile/TileGrid.hpp"
+#include "tile/TileKey.hpp"
+
+using namespace slippygl;
+using namespace slippygl::render;
+using namespace slippygl::tile;
+
+// Mirrors the app loop's zoom-level stepping + camera remap.
+static int step(Camera2D& cam, int z)
+{
+    while (cam.scale() > 2.0f && z < 19) { ++z; cam.applyZoomStep(2.0f); }
+    while (cam.scale() < 0.5f && z > 0)  { --z; cam.applyZoomStep(0.5f); }
+    return z;
+}
+
+static void expectValidRange(const Camera2D& cam, int z, int fbW, int fbH)
+{
+    const auto r = TileGrid::computeVisibleRange(cam, fbW, fbH, z);
+    const int maxIdx = (1 << z) - 1;
+    CHECK(r.tileCount() > 0);     // never silently empty
+    CHECK(r.minX <= r.maxX);      // never inverted
+    CHECK(r.minY <= r.maxY);
+    CHECK(r.minX >= 0);
+    CHECK(r.maxX <= maxIdx);
+    CHECK(r.minY >= 0);
+    CHECK(r.maxY <= maxIdx);
+}
+
+void test_tilegrid()
+{
+    std::printf("[tilegrid]\n");
+
+    const int fbW = 800, fbH = 600;
+    int z = 12;
+    Camera2D cam;
+    const glm::vec2 wp = tileToWorldPixel(TileKey{ 12, 3492, 1586 }); // Seoul
+    cam.setWorldOrigin(glm::vec2(wp.x + 128.0f - fbW / 2.0f, wp.y + 128.0f - fbH / 2.0f));
+
+    // initial
+    expectValidRange(cam, z, fbW, fbH);
+
+    // zoom OUT repeatedly: tiles must stay visible (regression: was 0 tiles)
+    for (int i = 0; i < 40; ++i) { cam.zoomAt(fbW/2.0f, fbH/2.0f, -1.0f, fbW, fbH); z = step(cam, z); }
+    expectValidRange(cam, z, fbW, fbH);
+    CHECK(z < 12);
+
+    // zoom IN deeply
+    for (int i = 0; i < 120; ++i) { cam.zoomAt(fbW/2.0f, fbH/2.0f, 1.0f, fbW, fbH); z = step(cam, z); }
+    expectValidRange(cam, z, fbW, fbH);
+    CHECK(z > 12);
+
+    // Explicit inverted-range guard: an origin far past the world bounds at a
+    // low zoom must clamp (minX<=maxX), not invert.
+    Camera2D off;
+    off.setWorldOrigin(glm::vec2(1.0e6f, 1.0e6f));
+    const auto r = TileGrid::computeVisibleRange(off, fbW, fbH, 4);
+    CHECK(r.minX <= r.maxX);
+    CHECK(r.minY <= r.maxY);
+}

--- a/SlippyGL/tests/test_tilekey.cpp
+++ b/SlippyGL/tests/test_tilekey.cpp
@@ -1,0 +1,30 @@
+#include "check.hpp"
+#include "tile/TileKey.hpp"
+
+using namespace slippygl::tile;
+
+void test_tilekey()
+{
+    std::printf("[tilekey]\n");
+
+    CHECK_EQ(kTileSizePx, 256);
+
+    // world px <-> tile index
+    CHECK_EQ(TileCoord::worldPxToTileIndex(0.0f), 0);
+    CHECK_EQ(TileCoord::worldPxToTileIndex(255.0f), 0);
+    CHECK_EQ(TileCoord::worldPxToTileIndex(256.0f), 1);
+    CHECK_EQ(TileCoord::worldPxToTileIndex(-1.0f), -1);  // floor of negative
+    CHECK_EQ(TileCoord::tileIndexToWorldPx(0), 0.0f);
+    CHECK_EQ(TileCoord::tileIndexToWorldPx(5), 1280.0f);
+
+    // clamp to [0, 2^zoom - 1]
+    CHECK_EQ(TileCoord::clampTileIndex(-3, 5), 0);
+    CHECK_EQ(TileCoord::clampTileIndex(10, 5), 10);
+    CHECK_EQ(TileCoord::clampTileIndex(100, 5), 31);   // 2^5 - 1
+    CHECK_EQ(TileCoord::clampTileIndex(0, 0), 0);      // 2^0 - 1 = 0
+
+    // tile -> world pixel (top-left corner)
+    const glm::vec2 wp = tileToWorldPixel(TileKey{ 12, 3492, 1586 });
+    CHECK_EQ(wp.x, 3492.0f * 256.0f);
+    CHECK_EQ(wp.y, 1586.0f * 256.0f);
+}

--- a/SlippyGL/tests/test_tilemath.cpp
+++ b/SlippyGL/tests/test_tilemath.cpp
@@ -1,0 +1,39 @@
+#include "check.hpp"
+#include "core/TileMath.hpp"
+
+using namespace slippygl::core;
+
+void test_tilemath()
+{
+    std::printf("[tilemath]\n");
+
+    // Known value: Seoul City Hall (lon 126.9780, lat 37.5665) at zoom 12 -> 3492/1586
+    const TileID id = TileMath::lonlatToTileID(126.9780, 37.5665, 12);
+    CHECK_EQ(id.z(), 12);
+    CHECK_EQ(id.x(), 3492);
+    CHECK_EQ(id.y(), 1586);
+
+    // World pixel size doubles per zoom level
+    CHECK_EQ(TileMath::worldSizePx(0), 256);
+    CHECK_EQ(TileMath::worldSizePx(1), 512);
+    CHECK_EQ(TileMath::worldSizePx(12), 256 * 4096);
+
+    // Longitude maps -180..180 -> 0..world; 0 deg = horizontal center
+    const double world2 = static_cast<double>(TileMath::worldSizePx(2));
+    CHECK_NEAR(TileMath::lonToXpx(-180.0, 2), 0.0, 1e-6);
+    CHECK_NEAR(TileMath::lonToXpx(0.0, 2), world2 * 0.5, 1e-6);
+    // +180 deg normalizes to -180 (same meridian) -> wraps to the left edge (0)
+    CHECK_NEAR(TileMath::lonToXpx(180.0, 2), 0.0, 1e-6);
+    // just inside the antimeridian approaches the right edge
+    CHECK(TileMath::lonToXpx(179.0, 2) > world2 * 0.99);
+
+    // Latitude 0 deg = vertical center (Web Mercator)
+    CHECK_NEAR(TileMath::latToYpx(0.0, 2), world2 * 0.5, 1e-3);
+    // Northern latitudes map to smaller Y (closer to top)
+    CHECK(TileMath::latToYpx(60.0, 5) < TileMath::latToYpx(0.0, 5));
+
+    // px -> tile index is a floor
+    CHECK_EQ(TileMath::pxToTile(255.0), 0);
+    CHECK_EQ(TileMath::pxToTile(256.0), 1);
+    CHECK_EQ(TileMath::pxToTile(257.0), 1);
+}

--- a/SlippyGL/vcpkg.json
+++ b/SlippyGL/vcpkg.json
@@ -5,9 +5,6 @@
     "glfw3",
     "glad",
     "spdlog",
-
-    { "name": "curl", "default-features": false, "features": ["schannel"], "platform": "windows" },
-    { "name": "curl", "default-features": false, "features": ["openssl"], "platform": "!windows" },
-    { "name": "openssl", "platform": "!windows" }
+    "curl"
   ]
 }


### PR DESCRIPTION
## 개요
포트폴리오 신뢰도를 위해 **단위 테스트**와 **CI**를 추가합니다.

## 테스트 (의존성 0, GL/네트워크 불필요)
프레임워크 없는 경량 assert 하네스. `Camera2D` + `glm`만 링크해 어디서나 실행 가능.
- **tilemath**: 위경도→타일 known value(서울 z12 = 3492/1586), 월드 크기 배증, 좌표 변환, 자오선 wrap
- **tilekey**: 월드픽셀↔타일인덱스, `clampTileIndex` 경계, 타일→월드픽셀
- **tilegrid**: 줌인/줌아웃 시 가시 범위가 **비지 않고·범위 내·역전 없음** (줌 좌표 재매핑 회귀 테스트)
- **camera**: `applyZoomStep`이 레벨 전환 시 점의 화면 위치 보존, `screen↔world` 역변환, pan

`SLIPPYGL_BUILD_TESTS` 옵션 + `slippygl_tests` 타깃을 CTest에 연결.

## CI (`.github/workflows/ci.yml`)
- `windows-latest`에서 CMake + vcpkg configure → Release 빌드 → `ctest`
- vcpkg 의존성은 GitHub Actions 바이너리 캐시로 반복 실행 시 재빌드 방지

## 검증
- 로컬: **61 checks, 0 failures** (ctest 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)